### PR TITLE
BLD: upgraded to Solidity v0.5

### DIFF
--- a/contracts/JsmnSolLib.sol
+++ b/contracts/JsmnSolLib.sol
@@ -19,17 +19,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-pragma solidity ^0.4.23;
+pragma solidity ^0.5.0;
 
 library JsmnSolLib {
-    
-    enum JsmnType {UNDEFINED, OBJECT, ARRAY, STRING, PRIMITIVE}
-    
+
+    enum JsmnType { UNDEFINED, OBJECT, ARRAY, STRING, PRIMITIVE }
+
     uint constant RETURN_SUCCESS = 0;
     uint constant RETURN_ERROR_INVALID_JSON = 1;
     uint constant RETURN_ERROR_PART = 2;
     uint constant RETURN_ERROR_NO_MEM = 3;
-    
+
     struct Token {
         JsmnType jsmnType;
         uint start;
@@ -38,31 +38,31 @@ library JsmnSolLib {
         bool endSet;
         uint8 size;
     }
-    
+
     struct Parser {
         uint pos;
         uint toknext;
         int toksuper;
     }
-    
-    function init(uint length) pure internal returns (Parser, Token[]) {
-        Parser memory p = Parser(0, 0, - 1);
+
+    function init(uint length) internal pure returns (Parser memory, Token[] memory) {
+        Parser memory p = Parser(0, 0, -1);
         Token[] memory t = new Token[](length);
         return (p, t);
     }
-    
-    function allocateToken(Parser parser, Token[] tokens) pure internal returns (bool, Token) {
+
+    function allocateToken(Parser memory parser, Token[] memory tokens) internal pure returns (bool, Token memory) {
         if (parser.toknext >= tokens.length) {
             // no more space in tokens
-            return (false, tokens[tokens.length - 1]);
+            return (false, tokens[tokens.length-1]);
         }
         Token memory token = Token(JsmnType.UNDEFINED, 0, false, 0, false, 0);
         tokens[parser.toknext] = token;
         parser.toknext++;
         return (true, token);
     }
-    
-    function fillToken(Token token, JsmnType jsmnType, uint start, uint end) pure internal {
+
+    function fillToken(Token memory token, JsmnType jsmnType, uint start, uint end) internal pure {
         token.jsmnType = jsmnType;
         token.start = start;
         token.startSet = true;
@@ -70,16 +70,16 @@ library JsmnSolLib {
         token.endSet = true;
         token.size = 0;
     }
-    
-    function parseString(Parser parser, Token[] tokens, bytes s) pure internal returns (uint) {
+
+    function parseString(Parser memory parser, Token[] memory tokens, bytes memory s) internal pure returns (uint) {
         uint start = parser.pos;
         bool success;
         Token memory token;
         parser.pos++;
-        
-        for (; parser.pos < s.length; parser.pos++) {
+
+        for (; parser.pos<s.length; parser.pos++) {
             bytes1 c = s[parser.pos];
-            
+
             // Quote -> end of string
             if (c == '"') {
                 (success, token) = allocateToken(parser, tokens);
@@ -87,43 +87,42 @@ library JsmnSolLib {
                     parser.pos = start;
                     return RETURN_ERROR_NO_MEM;
                 }
-                fillToken(token, JsmnType.STRING, start + 1, parser.pos);
+                fillToken(token, JsmnType.STRING, start+1, parser.pos);
                 return RETURN_SUCCESS;
             }
-            
-            if (c == 92 && parser.pos + 1 < s.length) {
+
+            if (uint8(c) == 92 && parser.pos + 1 < s.length) {
                 // handle escaped characters: skip over it
                 parser.pos++;
                 if (s[parser.pos] == '\"' || s[parser.pos] == '/' || s[parser.pos] == '\\'
-                || s[parser.pos] == 'f' || s[parser.pos] == 'r' || s[parser.pos] == 'n'
-                || s[parser.pos] == 'b' || s[parser.pos] == 't') {
-                    continue;
-                } else {
-                    // all other values are INVALID
-                    parser.pos = start;
-                    return (RETURN_ERROR_INVALID_JSON);
-                }
+                    || s[parser.pos] == 'f' || s[parser.pos] == 'r' || s[parser.pos] == 'n'
+                    || s[parser.pos] == 'b' || s[parser.pos] == 't') {
+                        continue;
+                        } else {
+                            // all other values are INVALID
+                            parser.pos = start;
+                            return(RETURN_ERROR_INVALID_JSON);
+                        }
+                    }
             }
-        }
         parser.pos = start;
         return RETURN_ERROR_PART;
     }
-    
-    function parsePrimitive(Parser parser, Token[] tokens, bytes s) pure internal returns (uint) {
+
+    function parsePrimitive(Parser memory parser, Token[] memory tokens, bytes memory s) internal pure returns (uint) {
         bool found = false;
         uint start = parser.pos;
         byte c;
         bool success;
         Token memory token;
-        
         for (; parser.pos < s.length; parser.pos++) {
             c = s[parser.pos];
             if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ','
-            || c == 0x7d || c == 0x5d) {
-                found = true;
-                break;
+                || c == 0x7d || c == 0x5d) {
+                    found = true;
+                    break;
             }
-            if (c < 32 || c > 127) {
+            if (uint8(c) < 32 || uint8(c) > 127) {
                 parser.pos = start;
                 return RETURN_ERROR_INVALID_JSON;
             }
@@ -132,7 +131,7 @@ library JsmnSolLib {
             parser.pos = start;
             return RETURN_ERROR_PART;
         }
-        
+
         // found the end
         (success, token) = allocateToken(parser, tokens);
         if (!success) {
@@ -143,23 +142,22 @@ library JsmnSolLib {
         parser.pos--;
         return RETURN_SUCCESS;
     }
-    
-    function parse(string json, uint numberElements) pure internal returns (uint, Token[], uint) {
+
+    function parse(string memory json, uint numberElements) internal pure returns (uint, Token[] memory tokens, uint) {
         bytes memory s = bytes(json);
-        Parser memory parser;
         bool success;
+        Parser memory parser;
         (parser, tokens) = init(numberElements);
-        JsmnSolLib.Token[] memory tokens;
-        Token memory token;
-        
+
         // Token memory token;
         uint r;
         uint count = parser.toknext;
         uint i;
-        
-        for (; parser.pos < s.length; parser.pos++) {
+        Token memory token;
+
+        for (; parser.pos<s.length; parser.pos++) {
             bytes1 c = s[parser.pos];
-            
+
             // 0x7b, 0x5b opening curly parentheses or brackets
             if (c == 0x7b || c == 0x5b) {
                 count++;
@@ -167,7 +165,7 @@ library JsmnSolLib {
                 if (!success) {
                     return (RETURN_ERROR_NO_MEM, tokens, 0);
                 }
-                if (parser.toksuper != - 1) {
+                if (parser.toksuper != -1) {
                     tokens[uint(parser.toksuper)].size++;
                 }
                 token.jsmnType = (c == 0x7b ? JsmnType.OBJECT : JsmnType.ARRAY);
@@ -176,19 +174,19 @@ library JsmnSolLib {
                 parser.toksuper = int(parser.toknext - 1);
                 continue;
             }
-            
+
             // closing curly parentheses or brackets
             if (c == 0x7d || c == 0x5d) {
                 JsmnType tokenType = (c == 0x7d ? JsmnType.OBJECT : JsmnType.ARRAY);
                 bool isUpdated = false;
-                for (i = parser.toknext - 1; i >= 0; i--) {
+                for (i=parser.toknext-1; i>=0; i--) {
                     token = tokens[i];
                     if (token.startSet && !token.endSet) {
                         if (token.jsmnType != tokenType) {
                             // found a token that hasn't been closed but from a different type
                             return (RETURN_ERROR_INVALID_JSON, tokens, 0);
                         }
-                        parser.toksuper = - 1;
+                        parser.toksuper = -1;
                         tokens[i].end = parser.pos + 1;
                         tokens[i].endSet = true;
                         isUpdated = true;
@@ -198,15 +196,15 @@ library JsmnSolLib {
                 if (!isUpdated) {
                     return (RETURN_ERROR_INVALID_JSON, tokens, 0);
                 }
-                for (; i > 0; i--) {
+                for (; i>0; i--) {
                     token = tokens[i];
                     if (token.startSet && !token.endSet) {
                         parser.toksuper = int(i);
                         break;
                     }
                 }
-                
-                if (i == 0) {
+
+                if (i==0) {
                     token = tokens[i];
                     if (token.startSet && !token.endSet) {
                         parser.toksuper = uint128(i);
@@ -214,157 +212,157 @@ library JsmnSolLib {
                 }
                 continue;
             }
-            
+
             // 0x42
             if (c == '"') {
                 r = parseString(parser, tokens, s);
-                
+
                 if (r != RETURN_SUCCESS) {
                     return (r, tokens, 0);
                 }
                 //JsmnError.INVALID;
                 count++;
-                if (parser.toksuper != - 1)
-                    tokens[uint(parser.toksuper)].size++;
+				if (parser.toksuper != -1)
+					tokens[uint(parser.toksuper)].size++;
                 continue;
             }
-            
+
             // ' ', \r, \t, \n
             if (c == ' ' || c == 0x11 || c == 0x12 || c == 0x14) {
                 continue;
             }
-            
+
             // 0x3a
             if (c == ':') {
-                parser.toksuper = int(parser.toknext - 1);
+                parser.toksuper = int(parser.toknext -1);
                 continue;
             }
-            
+
             if (c == ',') {
-                if (parser.toksuper != - 1
-                && tokens[uint(parser.toksuper)].jsmnType != JsmnType.ARRAY
-                && tokens[uint(parser.toksuper)].jsmnType != JsmnType.OBJECT) {
-                    for (i = parser.toknext - 1; i >= 0; i--) {
-                        if (tokens[i].jsmnType == JsmnType.ARRAY || tokens[i].jsmnType == JsmnType.OBJECT) {
-                            if (tokens[i].startSet && !tokens[i].endSet) {
-                                parser.toksuper = int(i);
-                                break;
+                if (parser.toksuper != -1
+                    && tokens[uint(parser.toksuper)].jsmnType != JsmnType.ARRAY
+                    && tokens[uint(parser.toksuper)].jsmnType != JsmnType.OBJECT) {
+                        for(i = parser.toknext-1; i>=0; i--) {
+                            if (tokens[i].jsmnType == JsmnType.ARRAY || tokens[i].jsmnType == JsmnType.OBJECT) {
+                                if (tokens[i].startSet && !tokens[i].endSet) {
+                                    parser.toksuper = int(i);
+                                    break;
+                                }
                             }
                         }
                     }
-                }
                 continue;
             }
-            
+
             // Primitive
             if ((c >= '0' && c <= '9') || c == '-' || c == 'f' || c == 't' || c == 'n') {
-                if (parser.toksuper != - 1) {
+                if (parser.toksuper != -1) {
                     token = tokens[uint(parser.toksuper)];
                     if (token.jsmnType == JsmnType.OBJECT
-                    || (token.jsmnType == JsmnType.STRING && token.size != 0)) {
-                        return (RETURN_ERROR_INVALID_JSON, tokens, 0);
-                    }
+                        || (token.jsmnType == JsmnType.STRING && token.size != 0)) {
+                            return (RETURN_ERROR_INVALID_JSON, tokens, 0);
+                        }
                 }
-                
+
                 r = parsePrimitive(parser, tokens, s);
                 if (r != RETURN_SUCCESS) {
                     return (r, tokens, 0);
                 }
                 count++;
-                if (parser.toksuper != - 1) {
+                if (parser.toksuper != -1) {
                     tokens[uint(parser.toksuper)].size++;
                 }
                 continue;
             }
-            
+
             // printable char
             if (c >= 0x20 && c <= 0x7e) {
                 return (RETURN_ERROR_INVALID_JSON, tokens, 0);
             }
         }
-        
+
         return (RETURN_SUCCESS, tokens, parser.toknext);
     }
-    
-    function getBytes(string json, uint start, uint end) pure internal returns (string) {
+
+    function getBytes(string memory json, uint start, uint end) internal pure returns (string memory) {
         bytes memory s = bytes(json);
-        bytes memory result = new bytes(end - start);
-        for (uint i = start; i < end; i++) {
-            result[i - start] = s[i];
+        bytes memory result = new bytes(end-start);
+        for (uint i=start; i<end; i++) {
+            result[i-start] = s[i];
         }
         return string(result);
     }
-    
+
     // parseInt
-    function parseInt(string _a) pure internal returns (int) {
+    function parseInt(string memory _a) internal pure returns (int) {
         return parseInt(_a, 0);
     }
-    
+
     // parseInt(parseFloat*10^_b)
-    function parseInt(string _a, uint _b) pure internal returns (int) {
+    function parseInt(string memory _a, uint _b) internal pure returns (int) {
         bytes memory bresult = bytes(_a);
         int mint = 0;
         bool decimals = false;
         bool negative = false;
-        for (uint i = 0; i < bresult.length; i++) {
+        for (uint i=0; i<bresult.length; i++){
             if ((i == 0) && (bresult[i] == '-')) {
                 negative = true;
             }
-            if ((bresult[i] >= 48) && (bresult[i] <= 57)) {
-                if (decimals) {
-                    if (_b == 0) break;
+            if ((uint8(bresult[i]) >= 48) && (uint8(bresult[i]) <= 57)) {
+                if (decimals){
+                   if (_b == 0) break;
                     else _b--;
                 }
                 mint *= 10;
-                mint += int(bresult[i]) - 48;
-            } else if (bresult[i] == 46) decimals = true;
+                mint += uint8(bresult[i]) - 48;
+            } else if (uint8(bresult[i]) == 46) decimals = true;
         }
-        if (_b > 0) mint *= int(10 ** _b);
-        if (negative) mint *= - 1;
+        if (_b > 0) mint *= int(10**_b);
+        if (negative) mint *= -1;
         return mint;
     }
-    
-    function uint2str(uint i) pure internal returns (string){
+
+    function uint2str(uint i) internal pure returns (string memory){
         if (i == 0) return "0";
         uint j = i;
         uint len;
-        while (j != 0) {
+        while (j != 0){
             len++;
             j /= 10;
         }
         bytes memory bstr = new bytes(len);
         uint k = len - 1;
-        while (i != 0) {
-            bstr[k--] = byte(48 + i % 10);
+        while (i != 0){
+            bstr[k--] = bytes1(uint8(48 + i % 10));
             i /= 10;
         }
         return string(bstr);
     }
-    
-    function parseBool(string _a) pure public returns (bool) {
+
+    function parseBool(string memory _a) internal pure returns (bool) {
         if (strCompare(_a, 'true') == 0) {
             return true;
         } else {
             return false;
         }
     }
-    
-    function strCompare(string _a, string _b) pure internal returns (int) {
+
+    function strCompare(string memory _a, string memory _b) internal pure returns (int) {
         bytes memory a = bytes(_a);
         bytes memory b = bytes(_b);
         uint minLength = a.length;
         if (b.length < minLength) minLength = b.length;
         for (uint i = 0; i < minLength; i ++)
             if (a[i] < b[i])
-                return - 1;
+                return -1;
             else if (a[i] > b[i])
                 return 1;
         if (a.length < b.length)
-            return - 1;
+            return -1;
         else if (a.length > b.length)
             return 1;
         else
             return 0;
     }
-    
+
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.4;
+pragma solidity ^0.5.0;
 
 contract Migrations {
   address public owner;

--- a/test/TestArrays.sol
+++ b/test/TestArrays.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.5;
+pragma solidity ^0.5.0;
 
 import "truffle/Assert.sol";
 import "../contracts/JsmnSolLib.sol";

--- a/test/TestErrors.sol
+++ b/test/TestErrors.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity ^0.5.0;
 
 import "truffle/Assert.sol";
 import "../contracts/JsmnSolLib.sol";

--- a/test/TestHelpers.sol
+++ b/test/TestHelpers.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.5;
+pragma solidity ^0.5.0;
 
 import "truffle/Assert.sol";
 import "../contracts/JsmnSolLib.sol";

--- a/test/TestObjects.sol
+++ b/test/TestObjects.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.23;
+pragma solidity ^0.5.0;
 
 import "truffle/Assert.sol";
 import "../contracts/JsmnSolLib.sol";

--- a/test/TestPrimitives.sol
+++ b/test/TestPrimitives.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.5;
+pragma solidity ^0.5.0;
 
 import "truffle/Assert.sol";
 import "../contracts/JsmnSolLib.sol";

--- a/test/TestReturnValues.sol
+++ b/test/TestReturnValues.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.5;
+pragma solidity ^0.5.0;
 
 import "truffle/Assert.sol";
 import "../contracts/JsmnSolLib.sol";

--- a/test/TestUnicode.sol
+++ b/test/TestUnicode.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.5;
+pragma solidity ^0.5.0;
 
 import "truffle/Assert.sol";
 import "../contracts/JsmnSolLib.sol";


### PR DESCRIPTION
Addresses #11.

All tests pass locally:
```
$ truffle test
Compiling ./contracts/JsmnSolLib.sol...
Compiling ./contracts/Migrations.sol...
Compiling ./test/TestArrays.sol...
Compiling ./test/TestErrors.sol...
Compiling ./test/TestHelpers.sol...
Compiling ./test/TestObjects.sol...
Compiling ./test/TestPrimitives.sol...
Compiling ./test/TestReturnValues.sol...
Compiling ./test/TestUnicode.sol...


  TestArrays
    ✓ testSimpleArray (282ms)
    ✓ testFloatArray (185ms)

  TestErrors
    ✓ testTooFewTokens (245ms)

  TestHelpers
    ✓ testIntParser (79ms)
    ✓ testIntParserOneDecimal (66ms)
    ✓ testIntParserTwoDecimal (71ms)
    ✓ testIntParserNegative (74ms)

  TestObjects
    ✓ testSimpleObject (194ms)

  TestPrimitives
    ✓ testStringKeyValue (149ms)
    ✓ testLongerJson (448ms)
    ✓ testIntegerKeyValue (146ms)
    ✓ testNegativeIntegerKeyValue (164ms)
    ✓ testBoolKeyValue (165ms)
    ✓ testFloatKeyValue (361ms)

  TestReturnValues
    ✓ testNotEnoughMemory (233ms)
    ✓ testUnescapedQuoteInString (185ms)
    ✓ testEscapedQuoteInString (222ms)
    ✓ testNumberOfElements (252ms)

  TestUnicode
    ✓ testUmlaut (178ms)
    ✓ testDiacritcs (227ms)


  20 passing (1m)
```